### PR TITLE
Fix resume view when logged out

### DIFF
--- a/app/views/resumes/show.html.erb
+++ b/app/views/resumes/show.html.erb
@@ -16,10 +16,11 @@
 <br>
 <br>
 
-<%= render partial: 'reviews/form', locals: { review: Review.new, resume: @resume }%>
-
-<br>
-<br>
+<% if logged_in? %>
+  <%= render partial: 'reviews/form', locals: { review: Review.new, resume: @resume }%>
+  <br>
+  <br>
+<% end %>
 
 <%= render partial: 'reviews/table', locals: { reviews: @resume.reviews.reverse } %>
 

--- a/app/views/reviews/_table.html.erb
+++ b/app/views/reviews/_table.html.erb
@@ -8,7 +8,7 @@
         <span class="fa fa-star"></span>
       <% end %>
       <%= link_to review.user.username, review.user  %>
-      <% if review.user_id == current_user.id %>
+      <% if logged_in? && review.user_id == current_user.id %>
         <%= link_to '&times'.html_safe, review, method: :delete, data: { confirm: 'Are you sure?' }, style: "color:red", class: 'close' %>
       <% end %>
     </h5>


### PR DESCRIPTION
Prevents errors when a resume is viewed while a user is logged out. This is a temporary fix, since this interface will probably be removed in the future anyways